### PR TITLE
Update postinst to properly link kernel modules

### DIFF
--- a/scripts/postinst
+++ b/scripts/postinst
@@ -17,7 +17,7 @@ $MKDIR_P /etc/default /etc/exports.d
 $CP_A --preserve=links $SYNOPKG_PKGDEST/usr/lib/systemd/system/* /usr/lib/systemd/system/
 
 for m in $(find $SYNOPKG_PKGDEST/lib/modules -type f); do
-    $LN_S $m /lib/modules/asd
+    $LN_S $m /lib/modules/${m##*/}
 done
 
 $LN_S $SYNOPKG_PKGDEST/etc/default/* /etc/default/


### PR DESCRIPTION
The previous script only linked one module (either zfs or spl) to 'asd' as a hardcoded value - this will use the name of the actual module.